### PR TITLE
Fix nearest neighbor overlap calculation

### DIFF
--- a/orthogonal_projection/evaluation.py
+++ b/orthogonal_projection/evaluation.py
@@ -18,10 +18,20 @@ def compute_distortion(X, Y, epsilon=1e-9):
 def nearest_neighbor_overlap(X, Y, k=10):
     """Evaluate nearest-neighbor preservation after projection."""
     from sklearn.neighbors import NearestNeighbors
-    nn_original = NearestNeighbors(n_neighbors=k).fit(X)
-    nn_reduced = NearestNeighbors(n_neighbors=k).fit(Y)
+    # Request k+1 neighbors so that each point's own index (distance zero)
+    # is included and can be removed before computing the overlap. This
+    # prevents artificially inflating the score by counting each point as its
+    # own nearest neighbor.
+    n_neighbors = min(k + 1, len(X))
+    nn_original = NearestNeighbors(n_neighbors=n_neighbors).fit(X)
+    nn_reduced = NearestNeighbors(n_neighbors=n_neighbors).fit(Y)
     _, idx_original = nn_original.kneighbors(X)
     _, idx_reduced = nn_reduced.kneighbors(Y)
+
+    # Drop the first column which corresponds to the point itself
+    idx_original = idx_original[:, 1:]
+    idx_reduced = idx_reduced[:, 1:]
+
     overlap = [
         len(set(idx_original[i]) & set(idx_reduced[i])) / k
         for i in range(len(X))


### PR DESCRIPTION
## Summary
- fix nearest neighbor overlap computation by excluding each point itself

## Testing
- `python -m py_compile main.py orthogonal_projection/*.py tests/*.py`