### PR TITLE
Fix distortion computation

### DIFF
--- a/orthogonal_projection/evaluation.py
+++ b/orthogonal_projection/evaluation.py
@@ -12,8 +12,13 @@ def compute_distortion(X, Y, epsilon=1e-9):
     # Avoid division by zero or near-zero distances
     distortion = np.abs(D_red_sq - D_orig_sq) / (D_orig_sq + epsilon)
 
+    # Mask out the diagonal so self-distances do not skew the statistics
+    mask = ~np.eye(distortion.shape[0], dtype=bool)
+    distortion_mean = distortion[mask].mean()
+    distortion_max = distortion[mask].max()
+
     # Return the distance matrices for debugging if needed
-    return distortion.mean(), distortion.max(), D_orig_sq, D_red_sq
+    return distortion_mean, distortion_max, D_orig_sq, D_red_sq
 
 def nearest_neighbor_overlap(X, Y, k=10):
     """Evaluate nearest-neighbor preservation after projection."""

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,24 @@
+import numpy as np
+from sklearn.metrics import pairwise_distances
+
+from orthogonal_projection.evaluation import compute_distortion
+
+
+def test_compute_distortion_ignores_diagonal():
+    # Simple dataset of three points
+    X = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+    # Scale the data to induce non-zero distortion
+    Y = 2.0 * X
+
+    mean_d, max_d, D_orig_sq, D_red_sq = compute_distortion(X, Y)
+
+    # Manually compute expected distortion ignoring the diagonal
+    D_original = pairwise_distances(X) ** 2
+    D_reduced = pairwise_distances(Y) ** 2
+    distortion = np.abs(D_reduced - D_original) / (D_original + 1e-9)
+    mask = ~np.eye(distortion.shape[0], dtype=bool)
+    expected_mean = distortion[mask].mean()
+    expected_max = distortion[mask].max()
+
+    assert np.isclose(mean_d, expected_mean)
+    assert np.isclose(max_d, expected_max)


### PR DESCRIPTION
## Summary
- exclude self-pairs when computing distortion
- add regression test for compute_distortion ignoring diagonals

## Testing
- `pytest -q` *(fails: command not found)*